### PR TITLE
macOS install Instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.o
 a.out
 *~
+.DS_Store*

--- a/hw/HW0_PrepareCourse.md
+++ b/hw/HW0_PrepareCourse.md
@@ -12,10 +12,11 @@ If you have a Mac, Vivado will not install, so you will have to use
       Note that vlab gives you a computer to use, but when you log out your storage is gone. So you must write your results to a memory stick if you are in person, or email to yourself. This is inconvenient, so if at all possible I recommend installing on your computer.
 1. Install Icarus Verilog. This works on Windows, MacOS (with work)
  and Linux.
-   - [Icarus Verilog on MacOS](https://ee.sonoma.edu/current-students/resources/how-install-icarus-and-gtkwave-mac)
+   - Icarus Verilog + gtkwave on MacOS
+      - [Tutorial: installing iverilog + gtkwave macOS](IcarusVerilogInstallationGuide-macOS.md)
    - [Icarus Verilog on Windows](https://bleyer.org/icarus/)
-   - [Tutorial: installing iverilog Windows](IcarusVerilogInstallationGuide.pdf)
-   - [Tutorial: installing Vivado Windows](VivadoInstallationGuide.docx)
+      - [Tutorial: installing iverilog Windows](IcarusVerilogInstallationGuide.pdf)
+      - [Tutorial: installing Vivado Windows](VivadoInstallationGuide.docx)
 1. Get ready to use a CAD package to draw your circuits. Your choices are:
    - [Use TinkerCAD, a web-based CAD package, free from Autodesk](https://www.tinkercad.com/) *do this first*
    - [KiCAD (much more sophisticated, open source)](https://www.kicad.org/download/)

--- a/hw/IcarusVerilogInstallationGuide-macOS.md
+++ b/hw/IcarusVerilogInstallationGuide-macOS.md
@@ -1,0 +1,24 @@
+# Icarus Verilog + gtkwave Install Guide (macOS)
+
+## Installing Brew (Homebrew)
+
+- Brew is a package manager for macOS. It can install applications as well as various different commands/tools. We will be using it to install Icarus Verilog as well as gtkwave.
+
+1. Go to [brew.sh](https://brew.sh/) and copy the command shown on the website.
+2. Open the Terminal app on your computer, paste the command (CMD + V), and hit the Enter key.
+3. If you are asked for a password, enter your current user's password into the terminal. Your user MUST have superuser privilege.
+4. If the Terminal requests XCode Tools to be installed, accept and allow it access.
+5. Once Brew has finished installing, there are additional instructions that need to be ran manually. Copy and paste the given commands as needed.
+6. If all goes well, then typing ``brew`` into Terminal should yield example usage. If you're having trouble, double check there are no errors 
+7. That's it! Just run ``brew update && brew upgrade`` whenever you need to update all packages.
+
+## Installing Icarus Verilog
+
+1. In Terminal, type the command ``brew install iverilog``
+2. If everything goes well, you should be able to use the ``iverilog`` command in Terminal.
+
+## Installing gtkwave
+
+Installing gtkwave will be a bit more involved, as we are installing from a tap (3rd party repository)
+1. ``brew install --HEAD randomplum/gtkwave/gtkwave``
+2. If the installation is sucessful, running ``gtkwave`` from Terminal should launch the gtkwave app. gtkwave can also be found in your Applications folder.

--- a/hw/IcarusVerilogInstallationGuide-macOS.md
+++ b/hw/IcarusVerilogInstallationGuide-macOS.md
@@ -4,17 +4,29 @@
 
 - Brew is a package manager for macOS. It can install applications as well as various different commands/tools. We will be using it to install Icarus Verilog as well as gtkwave.
 
-1. Go to [brew.sh](https://brew.sh/) and copy the command shown on the website.
-2. Open the Terminal app on your computer, paste the command (CMD + V), and hit the Enter key.
-3. If you are asked for a password, enter your current user's password into the terminal. Your user MUST have superuser privilege.
-4. If the Terminal requests XCode Tools to be installed, accept and allow it access.
-5. Once Brew has finished installing, there are additional instructions that need to be ran manually. Copy and paste the given commands as needed.
-6. If all goes well, then typing ``brew`` into Terminal should yield example usage. If you're having trouble, double check there are no errors 
-7. That's it! Just run ``brew update && brew upgrade`` whenever you need to update all packages.
+1. Open the Terminal app. Run the following command in Terminal 
+```
+xcode-select --install
+```
+If Terminal asks for permissions make sure to allow/accept.
+
+2. Go to [brew.sh](https://brew.sh/) and copy the command shown on the website.
+
+3. Open the Terminal app on your computer and run the copied command.
+
+4. If you are asked for a password, enter your current user's password into the terminal. Your user MUST have superuser privilege.
+
+5. If the Terminal requests XCode Tools to be installed, accept and allow it access.
+
+6. Once Brew has finished installing, there are additional instructions that need to be ran manually. Copy and paste the given commands as needed.
+
+7. If all goes well, then running ``brew`` in Terminal should yield example usage. If you're having trouble, double check there are no errors and rerun the installation process.
+
+8. That's it! Just run ``brew update && brew upgrade`` whenever you need to update all packages.
 
 ## Installing Icarus Verilog
 
-1. In Terminal, type the command ``brew install iverilog``
+1. In Terminal, run the command ``brew install iverilog``
 2. If everything goes well, you should be able to use the ``iverilog`` command in Terminal.
 
 ## Installing gtkwave

--- a/hw/IcarusVerilogInstallationGuide-macOS.md
+++ b/hw/IcarusVerilogInstallationGuide-macOS.md
@@ -18,7 +18,7 @@ If Terminal asks for permissions make sure to allow/accept.
 
 5. If the Terminal requests XCode Tools to be installed, accept and allow it access.
 
-6. Once Brew has finished installing, there are additional instructions that need to be ran manually. Copy and paste the given commands as needed.
+6. Once Brew has finished installing, there are additional commands that need to be ran manually. Copy and paste the given commands as needed.
 
 7. If all goes well, then running ``brew`` in Terminal should yield example usage. If you're having trouble, double check there are no errors and rerun the installation process.
 


### PR DESCRIPTION
This PR adds an installation guide for installing Brew, a package manager needed to install iverilog and gtkwave.